### PR TITLE
Add required Linc dependencies to haxelib.json

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -8,5 +8,12 @@
     "classPath": "src/",
     "releasenote": "",
     "contributors": ["jeremyfa"],
-    "dependencies": {}
+    "dependencies": {
+      "linc_ogg": "git:https://github.com/ceramic-engine/linc_ogg.git",
+      "linc_openal": "git:https://github.com/ceramic-engine/linc_openal.git",
+      "linc_opengl": "git:https://github.com/ceramic-engine/linc_opengl.git",
+      "linc_sdl": "git:https://github.com/ceramic-engine/linc_sdl.git",
+      "linc_stb": "git:https://github.com/ceramic-engine/linc_stb.git",
+      "linc_timestamp": "git:https://github.com/ceramic-engine/linc_timestamp.git"
+    }
   }


### PR DESCRIPTION
Not sure if clay is ready for this, but I took the liberty of adding the current required linc dependency forks into the project's `haxelib.json`, to help make it easier to install and manage clay through haxelib 👍 