### PR TITLE
Fix build errors when Ceramic is not present

### DIFF
--- a/src/clay/BackgroundQueue.hx
+++ b/src/clay/BackgroundQueue.hx
@@ -47,10 +47,14 @@ class BackgroundQueue {
         pending.push(fn);
         mutex.release();
 
-        #else
+        #elseif ceramic
 
         // Defer in main thread if background threading is not available
         ceramic.App.app.onceImmediate(fn);
+
+        #else
+
+        fn();
 
         #end
 

--- a/src/clay/Runner.hx
+++ b/src/clay/Runner.hx
@@ -7,8 +7,6 @@ import sys.thread.Deque;
 import sys.thread.Thread;
 #end
 
-import ceramic.Shortcuts.*;
-
 /**
 A simple Haxe class for easily running threads and calling functions on the primary thread.
 from https://github.com/underscorediscovery/


### PR DESCRIPTION
Fixes build errors introduced in ac7ac34 that occur when the `ceramic` lib is not present.